### PR TITLE
Imrpove getBoundingClientRect

### DIFF
--- a/src/polyfills/element-getboundingrect.js
+++ b/src/polyfills/element-getboundingrect.js
@@ -12,7 +12,7 @@ export default function () {
   ElementPrototype.getBoundingClientRect = function () {
     var boundingClientRect = ElementPrototype.innerGetBoundingClientRect.call(this)
 
-    if (!boundingClientRect.x) {
+    if (!('x' in boundingClientRect)) {
       // The rect we're returning is a ClientRect and not a DOMRect.
       boundingClientRect.x = boundingClientRect.left
       boundingClientRect.y = boundingClientRect.top


### PR DESCRIPTION
Theoretical `boundingClientRect.x` can equal 0. Then `if` not correct works. Use `in` instead.